### PR TITLE
fix: remove git-add from lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,12 +56,10 @@
   "lint-staged": {
     "src/**/*.{ts,tsx}": [
       "prettier --write",
-      "tslint -t verbose -p .",
-      "git add"
+      "tslint -t verbose -p ."
     ],
     "*.{md,json,yaml,js,jsx}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   }
 }


### PR DESCRIPTION
Newer versions of lint-staged do this for you